### PR TITLE
You can now copy permalinks

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,10 +10,12 @@
     },
     "dependencies": {
         "@graphiql/react": "^0.20.2",
+        "@graphiql/toolkit": "^0.9.1",
         "@solana/rpc-graphql": "2.0.0-experimental.d32897d",
         "@solana/web3.js": "2.0.0-experimental.d32897d",
         "graphiql": "^3.0.10",
         "graphql": "^16.8.1",
+        "lz-string": "^1.5.0",
         "next": "14.0.1",
         "react": "^18",
         "react-dom": "^18"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,7 +7,10 @@ settings:
 dependencies:
   '@graphiql/react':
     specifier: ^0.20.2
-    version: 0.20.2(@codemirror/language@6.0.0)(@types/node@20.8.10)(@types/react-dom@18.2.14)(@types/react@18.2.33)(graphql@16.8.1)(react-dom@18.2.0)(react@18.2.0)
+    version: 0.20.2(@codemirror/language@6.0.0)(@types/node@20.8.10)(@types/react-dom@18.2.14)(@types/react@18.2.33)(graphql-ws@5.14.3)(graphql@16.8.1)(react-dom@18.2.0)(react@18.2.0)
+  '@graphiql/toolkit':
+    specifier: ^0.9.1
+    version: 0.9.1(@types/node@20.8.10)(graphql-ws@5.14.3)(graphql@16.8.1)
   '@solana/rpc-graphql':
     specifier: 2.0.0-experimental.d32897d
     version: 2.0.0-experimental.d32897d
@@ -20,6 +23,9 @@ dependencies:
   graphql:
     specifier: ^16.8.1
     version: 16.8.1
+  lz-string:
+    specifier: ^1.5.0
+    version: 1.5.0
   next:
     specifier: 14.0.1
     version: 14.0.1(react-dom@18.2.0)(react@18.2.0)
@@ -3032,6 +3038,11 @@ packages:
     dependencies:
       yallist: 4.0.0
     dev: true
+
+  /lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
+    dev: false
 
   /markdown-it@12.3.2:
     resolution: {integrity: sha512-TchMembfxfNVpHkbtriWltGWc+m3xszaRD0CZup7GFFhzIgQqxIfn3eGj1yZpfuflzPvfkt611B2Q/Bsk1YnGg==}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -13,7 +13,14 @@ export const metadata: Metadata = {
 export default function RootLayout({ children }: { children: React.ReactNode }) {
     return (
         <html lang="en">
-            <body className={inter.className}>{children}</body>
+            <body className={inter.className}>
+                <main className="flex flex-col w-full h-screen divide-y divide-slate-300">
+                    <h1 className="px-5 py-4 text-xl font-bold text-transparent bg-clip-text bg-gradient-to-br from-indigo-500 to-fuchsia-500">
+                        Solana GraphQL Playground
+                    </h1>
+                    <div className="grow">{children}</div>
+                </main>
+            </body>
         </html>
     );
 }

--- a/src/components/ClusterSwitcher.tsx
+++ b/src/components/ClusterSwitcher.tsx
@@ -1,16 +1,19 @@
 import { StarIcon, ToolbarButton, ToolbarMenu } from '@graphiql/react';
 import Image from 'next/image';
 
-export type TargetCluster = 'devnet' | 'testnet';
+export enum Cluster {
+    DEVNET = 0,
+    TESTNET = 1,
+}
 
 type Props = Readonly<{
-    currentCluster: TargetCluster;
-    onClusterChange: (nextCluster: TargetCluster) => void;
+    currentCluster: Cluster;
+    onClusterChange: (nextCluster: Cluster) => void;
 }>;
 
 const CLUSTER_LABEL = {
-    devnet: 'Devnet',
-    testnet: 'Testnet',
+    [Cluster.DEVNET]: 'Devnet',
+    [Cluster.TESTNET]: 'Testnet',
 } as const;
 
 export function ClusterSwitcher({ currentCluster, onClusterChange }: Props) {
@@ -33,12 +36,12 @@ export function ClusterSwitcher({ currentCluster, onClusterChange }: Props) {
             }
             label="Select cluster"
         >
-            {(['devnet', 'testnet'] as TargetCluster[]).map(targetCluster => (
-                <ToolbarMenu.Item onSelect={onClusterChange.bind(null, targetCluster)}>
+            {[Cluster.DEVNET, Cluster.TESTNET].map(Cluster => (
+                <ToolbarMenu.Item onSelect={onClusterChange.bind(null, Cluster)}>
                     <StarIcon
-                        className={`inline pe-1 align-text-top ${targetCluster === currentCluster ? '' : 'invisible'}`}
+                        className={`inline pe-1 align-text-top ${Cluster === currentCluster ? '' : 'invisible'}`}
                     />{' '}
-                    {CLUSTER_LABEL[targetCluster]}
+                    {CLUSTER_LABEL[Cluster]}
                 </ToolbarMenu.Item>
             ))}
         </ToolbarMenu>

--- a/src/utils/permalink.ts
+++ b/src/utils/permalink.ts
@@ -1,0 +1,66 @@
+import { compressToEncodedURIComponent, decompressFromEncodedURIComponent } from 'lz-string';
+
+import { Cluster } from '@/components/ClusterSwitcher';
+
+type PermalinkedQuery = Readonly<{
+    cluster: Cluster;
+    query: string;
+    variables?: string;
+}>;
+
+const QUERY_OPERATION_HEADER = 'q';
+const VERSION_HEADER = '0';
+
+function encodeCluster(cluster: Cluster) {
+    // TODO: When custom URLs are supported encode/decode them with a prefix.
+    return `${cluster}`;
+}
+
+function decodeCluster(untrustedEncodedClusterString: string): Cluster {
+    if (!/^\d$/.test(untrustedEncodedClusterString)) {
+        throw new Error('Cluster malformed in permalink');
+    }
+    const clusterValue = parseInt(untrustedEncodedClusterString, 10);
+    if (!(clusterValue in Cluster)) {
+        throw new Error('Invalid cluster in permalink');
+    }
+    return clusterValue;
+}
+
+function createPermalinkSlug({ cluster, query, variables }: PermalinkedQuery): string {
+    return [
+        QUERY_OPERATION_HEADER,
+        VERSION_HEADER,
+        encodeCluster(cluster),
+        compressToEncodedURIComponent(query),
+        variables ? compressToEncodedURIComponent(variables) : null,
+    ]
+        .filter(Boolean)
+        .join(':');
+}
+
+export function createPermalink(permalinkedQuery: PermalinkedQuery) {
+    const url = new URL(process.env.VERCEL_URL || window.location.href);
+    url.pathname = '';
+    url.hash = createPermalinkSlug(permalinkedQuery);
+    return url;
+}
+
+export function parsePermlinkSlug(untrustedPermalinkString: string): PermalinkedQuery {
+    const parts = untrustedPermalinkString.split(':');
+    const [queryOperationHeader, version, encodedCluster, encodedQuery, encodedVariables] = parts;
+    if (queryOperationHeader !== QUERY_OPERATION_HEADER) {
+        throw new Error('Permalink malformed');
+    }
+    if (version !== VERSION_HEADER) {
+        throw new Error('Permalink version not recognized');
+    }
+    if (parts.length < 4 || parts.length > 5) {
+        throw new Error('Permalink malformed');
+    }
+    return {
+        cluster: decodeCluster(encodedCluster),
+        query: decompressFromEncodedURIComponent(encodedQuery),
+        variables: decompressFromEncodedURIComponent(encodedVariables) ?? undefined,
+    };
+}

--- a/src/utils/url-hash.ts
+++ b/src/utils/url-hash.ts
@@ -1,0 +1,33 @@
+import { useEffect, useMemo, useState } from 'react';
+
+function normalizeHash(rawHash: string) {
+    return rawHash.replace(/^#/, '');
+}
+
+export function useHash() {
+    const [hash, setHash] = useState(() => (typeof window !== 'undefined' ? normalizeHash(window.location.hash) : ''));
+
+    useEffect(() => {
+        function handleHashChange(e: HashChangeEvent) {
+            setHash(normalizeHash(new URL(e.newURL).hash));
+        }
+        window.addEventListener('hashchange', handleHashChange);
+        return () => {
+            window.removeEventListener('hashchange', handleHashChange);
+        };
+    }, []);
+
+    return useMemo(
+        () =>
+            [
+                hash,
+                function setHash(rawHash: string) {
+                    const nextHash = normalizeHash(rawHash);
+                    if (nextHash !== hash) {
+                        window.location.hash = nextHash;
+                    }
+                },
+            ] as const,
+        [hash],
+    );
+}


### PR DESCRIPTION
# Summary

In this PR we make the copy query button:

1. Update the URL
2. Copy a permalink for the query on the screen to the clipboard

When visiting that permalink we:

1. Unpack the query, cluster, and variables, and boot the UI.
2. Disable all of the `localStorage` stuff that saves queries, so that while you're in ’permalink mode’ you're not overwriting your saved queries from before

# Test plan

<div class='graphite__hidden'>
          <div>🎥 Video uploaded on Graphite:</div>
            <a href="https://app.graphite.dev/media/video/lE1zD7Jpg6mWNv3djNKZ/b9b3cf28-097f-4f6b-9cc9-7816845d0571.mov">
              <img src="https://app.graphite.dev/api/v1/graphite/video/thumbnail/lE1zD7Jpg6mWNv3djNKZ/b9b3cf28-097f-4f6b-9cc9-7816845d0571.mov">
            </a>
          </div>
<video src="https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/lE1zD7Jpg6mWNv3djNKZ/b9b3cf28-097f-4f6b-9cc9-7816845d0571.mov">Screen Recording 2023-12-20 at 11.28.40 PM.mov</video>

