### PR TITLE
Disable SSR for the `GraphiQL` component

### DIFF
--- a/src/components/Ide.tsx
+++ b/src/components/Ide.tsx
@@ -1,0 +1,15 @@
+import GraphiQL from 'graphiql';
+
+import { ClusterSwitcher } from '@/components/ClusterSwitcher';
+
+type Props = React.ComponentProps<typeof GraphiQL> & React.ComponentProps<typeof ClusterSwitcher>;
+
+export default function Ide({ currentCluster, onClusterChange: handleClusterChange, ...props }: Props) {
+    return (
+        <GraphiQL {...props}>
+            <GraphiQL.Logo>
+                <ClusterSwitcher currentCluster={currentCluster} onClusterChange={handleClusterChange} />
+            </GraphiQL.Logo>
+        </GraphiQL>
+    );
+}


### PR DESCRIPTION
This thing is fundamentally incompatible with SSR because it uses `window` _somewhere_ inside of it.

# Test plan

```shell
pnpm build
```

No more build errors.